### PR TITLE
python3 compatibility

### DIFF
--- a/model.py
+++ b/model.py
@@ -1,3 +1,20 @@
+# Copyright (C) 2018  Artsiom Sanakoyeu and Dmytro Kotovenko
+#
+# This file is part of Adaptive Style Transfer
+#
+# Adaptive Style Transfer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Adaptive Style Transfer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 from __future__ import division
 from __future__ import print_function
 

--- a/model.py
+++ b/model.py
@@ -1,20 +1,3 @@
-# Copyright (C) 2018  Artsiom Sanakoyeu and Dmytro Kotovenko
-#
-# This file is part of Adaptive Style Transfer
-#
-# Adaptive Style Transfer is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Adaptive Style Transfer is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
 from __future__ import division
 from __future__ import print_function
 
@@ -146,9 +129,12 @@ class Artgan(object):
                                             for key, pred in zip(self.output_photo_discr_predictions.keys(),
                                                                  self.output_photo_discr_predictions.values())}
 
-            self.discr_loss = tf.add_n(self.input_painting_discr_loss.values()) + \
-                              tf.add_n(self.input_photo_discr_loss.values()) + \
-                              tf.add_n(self.output_photo_discr_loss.values())
+#            print(list(self.input_painting_discr_loss.values()))
+ #           tf.add_n(list(self.input_painting_discr_loss.values()))
+
+            self.discr_loss = tf.add_n(list(self.input_painting_discr_loss.values())) + \
+                              tf.add_n(list(self.input_photo_discr_loss.values())) + \
+                              tf.add_n(list(self.output_photo_discr_loss.values()))
 
             # Compute discriminator accuracies.
             self.input_painting_discr_acc = {key: tf.reduce_mean(tf.cast(x=(pred > tf.zeros_like(pred)),
@@ -163,9 +149,9 @@ class Artgan(object):
                                                                        dtype=tf.float32)) * scale_weight[key]
                                            for key, pred in zip(self.output_photo_discr_predictions.keys(),
                                                                 self.output_photo_discr_predictions.values())}
-            self.discr_acc = (tf.add_n(self.input_painting_discr_acc.values()) + \
-                              tf.add_n(self.input_photo_discr_acc.values()) + \
-                              tf.add_n(self.output_photo_discr_acc.values())) / float(len(scale_weight.keys())*3)
+            self.discr_acc = (tf.add_n(list(self.input_painting_discr_acc.values())) + \
+                              tf.add_n(list(self.input_photo_discr_acc.values())) + \
+                              tf.add_n(list(self.output_photo_discr_acc.values()))) / float(len(scale_weight.keys())*3)
 
 
             # Generator.
@@ -174,7 +160,7 @@ class Artgan(object):
                                             for key, pred in zip(self.output_photo_discr_predictions.keys(),
                                                                  self.output_photo_discr_predictions.values())}
 
-            self.gener_loss = tf.add_n(self.output_photo_gener_loss.values())
+            self.gener_loss = tf.add_n(list(self.output_photo_gener_loss.values()))
 
             # Compute generator accuracies.
             self.output_photo_gener_acc = {key: tf.reduce_mean(tf.cast(x=(pred > tf.zeros_like(pred)),
@@ -182,7 +168,7 @@ class Artgan(object):
                                            for key, pred in zip(self.output_photo_discr_predictions.keys(),
                                                                 self.output_photo_discr_predictions.values())}
 
-            self.gener_acc = tf.add_n(self.output_photo_gener_acc.values()) / float(len(scale_weight.keys()))
+            self.gener_acc = tf.add_n(list(self.output_photo_gener_acc.values())) / float(len(scale_weight.keys()))
 
 
             # Image loss.

--- a/model.py
+++ b/model.py
@@ -146,8 +146,6 @@ class Artgan(object):
                                             for key, pred in zip(self.output_photo_discr_predictions.keys(),
                                                                  self.output_photo_discr_predictions.values())}
 
-#            print(list(self.input_painting_discr_loss.values()))
- #           tf.add_n(list(self.input_painting_discr_loss.values()))
 
             self.discr_loss = tf.add_n(list(self.input_painting_discr_loss.values())) + \
                               tf.add_n(list(self.input_photo_discr_loss.values())) + \

--- a/model.py
+++ b/model.py
@@ -146,7 +146,6 @@ class Artgan(object):
                                             for key, pred in zip(self.output_photo_discr_predictions.keys(),
                                                                  self.output_photo_discr_predictions.values())}
 
-
             self.discr_loss = tf.add_n(list(self.input_painting_discr_loss.values())) + \
                               tf.add_n(list(self.input_photo_discr_loss.values())) + \
                               tf.add_n(list(self.output_photo_discr_loss.values()))


### PR DESCRIPTION
In contrast to python2 dict.values in python3 doesn't return a list, which is required by tensorflow. Casting to list resolves the problem. I've tested the training phase under the following package versions (only selected important packages)

h5py                      2.8.0            py36h989c5e5_3  
jpeg                      9c                   h470a237_1    conda-forge
keras-applications        1.0.6                    py36_0  
keras-preprocessing       1.0.5                    py36_0  
numpy                     1.15.1          py36_blas_openblashd3ea46f_0    conda-forge
opencv                    3.4.2            py36h6fd60c2_1  
pandas                    0.23.4           py36hf8a1672_0    conda-forge
pillow                    5.3.0            py36hc736899_0    conda-forge
py-opencv                 3.4.2            py36hb342d67_1  
python                    3.6.7                h0371630_0  
scipy                     1.1.0           py36_blas_openblash7943236_201    conda-forge
tensorboard               1.12.0           py36hf484d3e_0  
tensorflow                1.12.0          mkl_py36h69b6ba0_0  
tensorflow-base           1.12.0          mkl_py36h3c3e929_0  
tqdm                      4.28.1                     py_0    conda-forge