### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 Please click on the image for a [high-res version](https://compvis.github.io/adaptive-style-transfer/images/adaptive-style-transfer_chart.jpg).
 
 ## Requirements
-- python 2.7
-- tensorflow 1.2.
+- python 3.6
+- tensorflow 1.12.0
 - PIL, numpy, scipy
 - tqdm
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Please click on the image for a [high-res version](https://compvis.github.io/ada
 - PIL, numpy, scipy
 - tqdm
 
-*Also tested in `python3.6 + tensorflow1.12.0`*
+*Also tested in `python3.6 + tensorflow 1.12.0`*
 
 ## Inference 
 #### Simplest van Gogh example

--- a/README.md
+++ b/README.md
@@ -11,10 +11,12 @@
 Please click on the image for a [high-res version](https://compvis.github.io/adaptive-style-transfer/images/adaptive-style-transfer_chart.jpg).
 
 ## Requirements
-- python 3.6
-- tensorflow 1.12.0
+- python 2.7
+- tensorflow 1.2.
 - PIL, numpy, scipy
 - tqdm
+
+*Also tested in `python3.6 + tensorflow1.12.0`*
 
 ## Inference 
 #### Simplest van Gogh example


### PR DESCRIPTION
The code can run in `python3.6 + tensorflow1.12.0`
No need for `python2.7 + tensorflow1.2.0`. 
It's really hard to install tensorflow1.2 in python2.7 environment, as the pip and conda do not support them now. The origin requirements mislead me to spend an hour installing them. However, I found that the environment already on my computer can work. :)