### PR TITLE
Fixed the issue with the specified checkpoint number not being picked

### DIFF
--- a/model.py
+++ b/model.py
@@ -525,9 +525,9 @@ class Artgan(object):
 
     def load(self, checkpoint_dir, ckpt_nmbr=None):
         if ckpt_nmbr:
-            if len([x for x in os.listdir(checkpoint_dir) if str(ckpt_nmbr) in x]) > 0:
+            if len([x for x in os.listdir(checkpoint_dir) if ("ckpt-" + str(ckpt_nmbr)) in x]) > 0:
                 print(" [*] Reading checkpoint %d from folder %s." % (ckpt_nmbr, checkpoint_dir))
-                ckpt_name = [x for x in os.listdir(checkpoint_dir) if str(ckpt_nmbr) in x][0]
+                ckpt_name = [x for x in os.listdir(checkpoint_dir) if ("ckpt-" + str(ckpt_nmbr)) in x][0]
                 ckpt_name = '.'.join(ckpt_name.split('.')[:-1])
                 self.initial_step = ckpt_nmbr
                 print("Load checkpoint %s. Initial step: %s." % (ckpt_name, self.initial_step))


### PR DESCRIPTION
I noticed that the current code will not always use the checkpoint number you specify with --ckpt_nmbr.

This happens cause the code will check if the number is present on the file name, and this might cause the wrong checkpoint number to be picked.

If you ask for --ckpt_nmbr=45000, but you also have checkpoint 145000 or 245000, it might pick that one instead. See below:

```
$ CUDA_VISIBLE_DEVICES=1 python main.py --model_name=model_monet_brushstrokes2_1408 --phase=inference --image_size=1080 --ii_dir=/home/jupyter/adaptive/images/input/ --save_dir=/home/jupyter/adaptive/images/output --ckpt_nmbr=45000 2>&1 |grep ckpt
INFO:tensorflow:Restoring parameters from ./models/model_monet_brushstrokes2_1408/checkpoint/model_monet_brushstrokes2_1408_245000.ckpt-245000
I1017 17:16:50.271316 140041538344384 saver.py:1280] Restoring parameters from ./models/model_monet_brushstrokes2_1408/checkpoint/model_monet_brushstrokes2_1408_245000.ckpt-245000
^C
```

With the proposed changes, the specified checkpoint number is used:

```
$ CUDA_VISIBLE_DEVICES=1 python main.py --model_name=model_monet_brushstrokes2_1408 --phase=inference --image_size=1080 --ii_dir=/home/jupyter/adaptive/images/input/ --save_dir=/home/jupyter/adaptive/images/output --ckpt_nmbr=45000 2>&1 |grep ckpt
INFO:tensorflow:Restoring parameters from ./models/model_monet_brushstrokes2_1408/checkpoint_long/model_monet_brushstrokes2_1408_45000.ckpt-45000
I1017 17:18:40.946353 140675476186560 saver.py:1280] Restoring parameters from ./models/model_monet_brushstrokes2_1408/checkpoint_long/model_monet_brushstrokes2_1408_45000.ckpt-45000
```